### PR TITLE
Updated npmignore to omit demo dir

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,6 @@ cancel-done-landscape.png
 cancel-done-portrait.png
 tool-bar.ios.ts
 tool-bar-common.ts
+references.d.ts
 tsconfig.json
+demo/


### PR DESCRIPTION
To reduce the plugin size in consuming apps, I suggest removing the demo project from the npm plugin sources. This commit simply changes the `.npmignore` to avoid publishing the `demo` folder in future updates.