### PR TITLE
Updated TypeScript build settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   ],
   "author": "Rajiv Narayana <rajivnarayana@gmail.com> (https://github.com/rajivnarayana)",
   "license": "MIT",
+  "scripts": {
+    "build": "tsc"
+  },
   "devDependencies": {
     "tns-core-modules": "^1.5.1"
   }

--- a/references.d.ts
+++ b/references.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="./node_modules/tns-core-modules/tns-core-modules.es2016.d.ts" />
+/// <reference path="./node_modules/tns-platform-declarations/ios.d.ts" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,17 @@
 {
     "compilerOptions": {
-        "target": "ES5",
+        "target": "es5",
         "module": "commonjs",
-        "declaration": false,
-        "noImplicitAny": false,
         "removeComments": true,
-        "noLib": false,
-        "preserveConstEnums": true,
-        "suppressImplicitAnyIndexErrors": true
+        "experimentalDecorators": true,
+        "lib": [
+            "es2016"
+        ]
     },
     
-    "filesGlob": [
-        "./**/*.ts",
-        "!./node_modules/**/*.ts"
-    ],
-    
     "exclude": [
-        "platforms"
+        "node_modules",
+        "platforms",
+        "demo"
     ]
 }


### PR DESCRIPTION
In an effort to make it easier for future contributors to build/update this plugin, I added a "tsc" build script to the app package. TypeScript sources can now be compiled to JavaScript with `npm run build` (NOTE: Requires typescript -- `npm install -g typescript`). To reduce TypeScript build errors/warnings, also added reference to core platform types.